### PR TITLE
Add client-side form validation before Firestore submit

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -1,0 +1,29 @@
+import { validateForm } from '../src/utils/validateForm.js';
+import { addDoc, collection } from 'firebase/firestore';
+
+// Assume `db` is initialized Firestore instance elsewhere
+const form = document.getElementById('caricature-form');
+
+form?.addEventListener('submit', async (e) => {
+  e.preventDefault();
+
+  const data = {
+    nome: document.getElementById('nome')?.value || '',
+    email: document.getElementById('email')?.value || '',
+    whatsapp: document.getElementById('whatsapp')?.value || ''
+  };
+
+  const { valid, errors } = validateForm({ email: data.email, whatsapp: data.whatsapp });
+  if (!valid) {
+    alert(errors.join('\n'));
+    return;
+  }
+
+  try {
+    await addDoc(collection(db, 'leads'), data);
+    alert('Pedido enviado com sucesso!');
+  } catch (err) {
+    console.error(err);
+    alert('Erro ao enviar. Tente novamente.');
+  }
+});

--- a/src/utils/validateForm.js
+++ b/src/utils/validateForm.js
@@ -1,0 +1,14 @@
+export function validateForm({ email, whatsapp }) {
+  const errors = [];
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    errors.push('Por favor, informe um e-mail válido.');
+  }
+  if (whatsapp) {
+    const digits = whatsapp.replace(/\D/g, '');
+    if (digits.length < 10) {
+      errors.push('O número de WhatsApp deve conter pelo menos 10 dígitos.');
+    }
+  }
+  return { valid: errors.length === 0, errors };
+}

--- a/src/utils/validateForm.ts
+++ b/src/utils/validateForm.ts
@@ -1,0 +1,29 @@
+export interface FormData {
+  email: string;
+  whatsapp?: string;
+}
+
+/**
+ * Validate email and WhatsApp fields.
+ * - Email must match basic format.
+ * - WhatsApp digits must have at least 10 characters when provided.
+ * Returns object with validity and list of error messages.
+ */
+export function validateForm({ email, whatsapp }: FormData): { valid: boolean; errors: string[] } {
+  const errors: string[] = [];
+
+  // Basic email pattern: something@domain.tld
+  const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+  if (!emailRegex.test(email)) {
+    errors.push('Por favor, informe um e-mail válido.');
+  }
+
+  if (whatsapp) {
+    const digits = whatsapp.replace(/\D/g, '');
+    if (digits.length < 10) {
+      errors.push('O número de WhatsApp deve conter pelo menos 10 dígitos.');
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}


### PR DESCRIPTION
## Summary
- add TypeScript `validateForm` utility with email and WhatsApp regex checks
- show specific validation errors before sending data to Firestore
- integrate validation into web app submission flow

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6899834b641c8320806cebaaa32f1649